### PR TITLE
Allow for searching for non-tex format files

### DIFF
--- a/kpathsea/src/lib.rs
+++ b/kpathsea/src/lib.rs
@@ -19,13 +19,72 @@ impl Kpaths {
     Kpaths(kpse)
   }
 
+  /// For a given filename, try to guess the kpse format type from the file
+  /// extension by looking it up in the format info table. This is a simplified
+  /// version of the find_format function in kpsewhich.
+  fn guess_format_from_filename(&self, filename: &str) -> kpse_file_format_type {
+    // We go through each format type
+    for format_type in 0..kpse_file_format_type_kpse_last_format {
+      let format_info = unsafe { (*self.0).format_info[format_type as usize] };
+
+      if format_info.type_.is_null() {
+        // If this format hasn't been initialized yet, initialize it now.
+        // Otherwise, it won't have the list of suffixes initialized.
+        unsafe {
+          kpathsea_init_format(self.0, format_type as kpse_file_format_type);
+        }
+      }
+
+      // First, we check the suffixes for each format type. The suffixes are
+      // stored as an array of strings with a null pointer denoting the last
+      // value. Also, the pointer to the array can itself be null if there are
+      // no suffixes.
+      let mut suffix_ptr = format_info.suffix;
+      while !suffix_ptr.is_null() && !unsafe {*suffix_ptr}.is_null() {
+        // Pull out the suffix
+        let suffix_cstr = unsafe { CStr::from_ptr(*suffix_ptr) };
+        let suffix = suffix_cstr.to_str().unwrap();
+
+        // We check if the last suffix.len() characters of the filename are
+        // equal to the suffix itself. If so, then we've found a type that
+        // matches our filename!
+        if filename.get(filename.len()-suffix.len()..) == Some(suffix) {
+          return format_type as kpse_file_format_type;
+        }
+
+        // Go to the next suffix in the array.
+        suffix_ptr = unsafe { suffix_ptr.offset(1) };
+      }
+
+      // Next, we check the alternate suffixes for each format type. This is
+      // stored in the exact same way as the normal suffixes.
+      // TODO(xymostech): factor this out into a function to avoid duplication
+      let mut alt_suffix_ptr = format_info.alt_suffix;
+      while !alt_suffix_ptr.is_null() && !unsafe {*alt_suffix_ptr}.is_null() {
+        let alt_suffix_cstr = unsafe { CStr::from_ptr(*alt_suffix_ptr) };
+        let alt_suffix = alt_suffix_cstr.to_str().unwrap();
+
+        if filename.get(filename.len()-alt_suffix.len()..) == Some(alt_suffix) {
+          return format_type as kpse_file_format_type;
+        }
+
+        alt_suffix_ptr = unsafe { alt_suffix_ptr.offset(1) };
+      }
+    }
+
+    // If we don't find any matching suffixes, we guess that it's a tex file
+    kpse_file_format_type_kpse_tex_format
+  }
+
   /// Find a file base name, auto-completing with the standard TeX extensions if needed
   pub fn find_file(&self, name: &str) -> Option<String> {
     let c_name = CString::new(name).unwrap();
+
+    let file_format_type = self.guess_format_from_filename(name);
     let c_filename_buf = unsafe { kpathsea_find_file(
       self.0,
       c_name.as_ptr(),
-      kpse_file_format_type_kpse_tex_format, // TODO: extend
+      file_format_type,
       0
     )};
     

--- a/kpathsea/tests/find_file.rs
+++ b/kpathsea/tests/find_file.rs
@@ -8,3 +8,13 @@ fn find_latex() {
    None => assert!(false, "article.cls wasn't detected on this system. Either your TeX/texlive installation or your kpathsea installation are missing/not visible.")
   };
 }
+
+#[test]
+fn it_finds_multiple_kinds_of_files() {
+  let kpse = Kpaths::new();
+
+  assert!(kpse.find_file("plain.tex").unwrap().ends_with("plain.tex"));
+  assert!(kpse.find_file("cmr10.tfm").unwrap().ends_with("cmr10.tfm"));
+  assert!(kpse.find_file("latex.ltx").unwrap().ends_with("latex.ltx"));
+  assert!(kpse.find_file("plain.mf").unwrap().ends_with("plain.mf"));
+}


### PR DESCRIPTION
Previously, we always defaulted to using the `kpse_tex_file_format` when
searching for files, which prevented using the library to search for
non-tex files (like font metrics, font glyphs, etc).

This adds a new `Kpaths::guess_format_from_filename` method which
guesses what format a filename has based on its extension. This is
based on a similar function in kpsewhich. Using this allows for almost
any format to be found.

The test I added is a bit crude and doesn't provide very good errors,
let me know if you'd like me to make that better before merging!