### PR TITLE
Use kpsewhich as the executable name to prevent problems finding TeX

### DIFF
--- a/kpathsea/Cargo.toml
+++ b/kpathsea/Cargo.toml
@@ -16,6 +16,7 @@ name = "kpathsea"
 
 [dependencies]
 kpathsea_sys = {version="0.1.0", path="../kpathsea_sys"}
+which = "2.0.1"
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg",  "kpathsea_docs_rs"]

--- a/kpathsea/tests/find_file.rs
+++ b/kpathsea/tests/find_file.rs
@@ -2,7 +2,7 @@ use kpathsea::Kpaths;
 
 #[test]
 fn find_latex() {
-  let kpse = Kpaths::new();
+  let kpse = Kpaths::new().unwrap();
   match kpse.find_file("article.cls") {
    Some(path) => assert!(path.ends_with("article.cls"), "Successfully found the full path of article.cls"),
    None => assert!(false, "article.cls wasn't detected on this system. Either your TeX/texlive installation or your kpathsea installation are missing/not visible.")
@@ -11,7 +11,7 @@ fn find_latex() {
 
 #[test]
 fn it_finds_multiple_kinds_of_files() {
-  let kpse = Kpaths::new();
+  let kpse = Kpaths::new().unwrap();
 
   assert!(kpse.find_file("plain.tex").unwrap().ends_with("plain.tex"));
   assert!(kpse.find_file("cmr10.tfm").unwrap().ends_with("cmr10.tfm"));


### PR DESCRIPTION
Fixes #2

This is one solution proposed as a solution to #2, where instead of
passing in the actual current executable name to
kpathsea_set_program_name, we pass in the path to `kpsewhich`. This
way, kpathsea will definitely be able to find the installed TeX
distribution.

My major qualm about this method is that it's not terribly clear to
the end user what's going on and which TeX distribution is going to be
selected. I guess most people probably only have 1, and this makes it
easy for the general user of the library, but it does remove some
choice. The method of using env variables is really cumbersome (especially
if someone uses this library in something more unrelated to TeX and then 
their users have the burden of figuring it out too), but it does give users
more choice, I guess.

The only other problem I have with this is it'll show the
wrong name when kpathsea spits out errors, but that's probably not a
huge deal.

Thoughts, @dginev?