### PR TITLE
Fix bug in `guess_format_from_filename`

### DIFF
--- a/kpathsea/src/lib.rs
+++ b/kpathsea/src/lib.rs
@@ -47,7 +47,7 @@ impl Kpaths {
   fn guess_format_from_filename(&self, filename: &str) -> kpse_file_format_type {
     // We go through each format type
     for format_type in 0..kpse_file_format_type_kpse_last_format {
-      let format_info = unsafe { (*self.0).format_info[format_type as usize] };
+      let format_info = unsafe { &(*self.0).format_info[format_type as usize] };
 
       if format_info.type_.is_null() {
         // If this format hasn't been initialized yet, initialize it now.

--- a/kpathsea/tests/find_file.rs
+++ b/kpathsea/tests/find_file.rs
@@ -16,8 +16,8 @@ fn it_finds_multiple_kinds_of_files() {
   let kpse = Kpaths::new()
     .expect("You need a properly setup tex toolchain (texlive/MikTeX/...) and kpathsea headers, to use this wrapper.");
 
-  assert!(kpse.find_file("plain.tex").unwrap().ends_with("plain.tex"));
   assert!(kpse.find_file("cmr10.tfm").unwrap().ends_with("cmr10.tfm"));
+  assert!(kpse.find_file("plain.tex").unwrap().ends_with("plain.tex"));
   assert!(kpse.find_file("latex.ltx").unwrap().ends_with("latex.ltx"));
   assert!(kpse.find_file("plain.mf").unwrap().ends_with("plain.mf"));
 }


### PR DESCRIPTION
It turns out that there was a bug in how I was initializing the
formats when they weren't already initialized. I was fetching a *copy*
of the format info struct, and then initializing the format if it
wasn't filled in, but this didn't end up filling in the copy of the
struct, so lookups would fail. Miraculously, in the test for this
function, I chose to look for a `.tex` file first, which then went and
initialized all of the formats, returned the default of
`kpse_tex_format`, so that lookup worked, and then in the later
lookups the formats were already initialized. Oops.

This fixes the problem by fetching a reference to the format info
struct, which then actually gets updated when `kpathsea_init_format`
runs.

I guess I'm not super enthused about storing a non-mutable reference
to something and then magically having it update in
`kpathsea_init_format`. An alternate solution would maybe look like:
```rust
      // Note no &
      let mut format_info = unsafe { (*self.0).format_info[format_type as usize] };

      if format_info.type_.is_null() {
        // If this format hasn't been initialized yet, initialize it now.
        // Otherwise, it won't have the list of suffixes initialized.
        unsafe {
          kpathsea_init_format(self.0, format_type as kpse_file_format_type);
        }

        // Get a new copy of the struct
        format_info = unsafe { (*self.0).format_info[format_type as usize] };
      }
```
What do you think, @dginev?

Test plan: `cargo test -- --test-threads=1`