### PR TITLE
Bug fix

### DIFF
--- a/kpathsea/src/lib.rs
+++ b/kpathsea/src/lib.rs
@@ -74,7 +74,7 @@ impl Kpaths {
         // We check if the last suffix.len() characters of the filename are
         // equal to the suffix itself. If so, then we've found a type that
         // matches our filename!
-        if filename.get(filename.len()-suffix.len()..) == Some(suffix) {
+        if filename.len()>suffix.len() && filename.get(filename.len()-suffix.len()..) == Some(suffix) {
           return format_type as kpse_file_format_type;
         }
 


### PR DESCRIPTION
occasionally causes a "attempt to subtract with overflow"-error for short filenames without file ending (I'm guessing), e.g. in "\input catkoi" in ruhyphen.tex