### PR TITLE
subprocess: suppress MiKTeX's on-the-fly installer (0.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## [0.3.2] 2026-07-14 — subprocess backend: never block on MiKTeX's on-the-fly installer
+
+* **The subprocess backend no longer deadlocks on MiKTeX package installation.**
+  MiKTeX's `kpsewhich` triggers its on-the-fly package installer when asked for a
+  file whose package is known to the distribution but not installed; with the
+  default `[MPM]AutoInstall = Ask` this raises a blocking (often interactive)
+  prompt that hangs a non-interactive caller until an outer timeout kills it. The
+  subprocess backend now prepends `--miktex-disable-installer` to every
+  `kpsewhich` call on MiKTeX, so a missing package resolves to "not found"
+  immediately (graceful degradation) instead of prompting. The option is detected
+  once per executable by **capability probe** — `kpsewhich
+  --miktex-disable-installer --version`, which does no file lookup and so cannot
+  itself trigger the installer; a zero exit means the flag is understood. TeX Live
+  (and any distro that rejects the option) is unaffected — the prepended prefix is
+  empty. No API change; installed-file resolution is unchanged. Motivated by
+  `dginev/latexml-oxide`'s Windows release on MiKTeX hosts.
+
 ## [0.3.1] 2026-07-14 — opt-in `build_from_source`; kpathsea_sys 0.2.2
 
 * **`kpathsea_sys` 0.2.2 — new opt-in `build_from_source` feature.** Builds a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "kpathsea"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kpathsea_sys",
  "which",

--- a/kpathsea/Cargo.toml
+++ b/kpathsea/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kpathsea"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>", "Emily Eisenberg <xymostech@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/kpathsea/src/subprocess.rs
+++ b/kpathsea/src/subprocess.rs
@@ -67,6 +67,10 @@ struct SharedKpse {
   /// Locked only on the `lsr`-miss path, where the alternative is a
   /// ~150ms spawn.
   memo: Mutex<HashMap<String, Option<String>>>,
+  /// Flags prepended to EVERY direct `kpsewhich` call for this executable —
+  /// empty on most distributions, `["--miktex-disable-installer"]` on MiKTeX.
+  /// Computed once (see [`probe_installer_args`]); immutable after build.
+  installer_args: Vec<String>,
 }
 
 /// One [`SharedKpse`] per `kpsewhich` executable — Perl's `$kpse_cache`
@@ -88,6 +92,7 @@ fn shared_kpse(kpsewhich: &Path) -> Arc<SharedKpse> {
   let built = Arc::new(SharedKpse {
     lsr: build_kpse_cache(kpsewhich),
     memo: Mutex::new(HashMap::new()),
+    installer_args: probe_installer_args(kpsewhich),
   });
   let mut registry = KPSE_REGISTRY.lock().unwrap_or_else(PoisonError::into_inner);
   Arc::clone(registry.entry(kpsewhich.to_path_buf()).or_insert(built))
@@ -202,7 +207,13 @@ impl SubprocessKpse {
     // The memo lock is NOT held during the spawn: concurrent lookups of
     // the same unmemoized query may each spawn once (benign — identical
     // results, last insert wins).
+    //
+    // `installer_args` (empty except on MiKTeX) is prepended so a request for
+    // a not-installed package can never trigger MiKTeX's blocking on-the-fly
+    // installer. It is constant per executable, so it is NOT part of the memo
+    // key (which distinguishes queries, not the fixed prefix).
     let result = Command::new(&self.kpsewhich)
+      .args(&self.shared().installer_args)
       .args(flags)
       .args(&names)
       .output()
@@ -227,6 +238,38 @@ impl SubprocessKpse {
       .memo
       .lock()
       .unwrap_or_else(PoisonError::into_inner)
+  }
+}
+
+/// One-time probe: the flags to prepend to every `kpsewhich` call for this
+/// executable so a lookup can never block on package installation.
+///
+/// MiKTeX's `kpsewhich` triggers its **on-the-fly package installer** when
+/// asked for a file whose package is known to the distribution but not
+/// installed. With the default `[MPM]AutoInstall = Ask`, that raises a blocking
+/// (interactive) prompt — which deadlocks a non-interactive caller until an
+/// outer timeout kills it. MiKTeX accepts `--miktex-disable-installer` to turn
+/// the installer off for the invocation, so a missing package resolves to "not
+/// found" immediately instead (graceful degradation, no prompt).
+///
+/// TeX Live's `kpsewhich` REJECTS the option (`unrecognized option`, non-zero
+/// exit), so it must be applied only where accepted. We detect that by capability
+/// rather than by matching a distribution name: `--version` performs no file
+/// lookup (so the probe itself can never trigger the installer), and a zero exit
+/// means the flag is understood. Runs once per executable, at [`shared_kpse`]
+/// construction; the result is stored on [`SharedKpse`] and reused for every
+/// later lookup — no per-call detection.
+fn probe_installer_args(kpsewhich: &Path) -> Vec<String> {
+  let accepts = Command::new(kpsewhich)
+    .arg("--miktex-disable-installer")
+    .arg("--version")
+    .output()
+    .map(|out| out.status.success())
+    .unwrap_or(false);
+  if accepts {
+    vec!["--miktex-disable-installer".to_string()]
+  } else {
+    Vec::new()
   }
 }
 


### PR DESCRIPTION
MiKTeX's `kpsewhich` triggers its on-the-fly package installer when asked for a file whose package is known to the distribution but not installed. With the default `[MPM]AutoInstall = Ask`, that raises a blocking (often interactive) prompt which deadlocks a non-interactive caller until an outer timeout kills it — so a document referencing any not-yet-installed package hangs.

**Fix:** prepend `--miktex-disable-installer` to every `kpsewhich` call on MiKTeX, so a missing package resolves to "not found" immediately (graceful degradation) instead of prompting.

- Detected **once per executable** by capability probe: `kpsewhich --miktex-disable-installer --version` does no file lookup (so the probe itself can never trigger the installer), and a zero exit means the flag is understood. Result stored on `SharedKpse` (built once per executable) and reused — no per-call detection.
- **TeX Live rejects the option** (`unrecognized option`), so it is applied only where accepted — the prepended prefix is empty there. Verified TeX Live/MiKTeX behavior on Windows.
- No API change; installed-file resolution unchanged (`find_file` suite green on MiKTeX with the flag prepended).

Motivated by dginev/latexml-oxide's Windows release on MiKTeX hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)