### PR TITLE
build_from_source: fix _stat64i32 LNK2005 under static CRT + LTO (0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Change Log
 
+## [0.3.3] 2026-07-14 — build_from_source: fix `_stat64i32` LNK2005 under static CRT + LTO
+
+* **`kpathsea_sys` 0.2.3 — the `build_from_source` static link now works under
+  `+crt-static` + fat-LTO.** The MSVC leg compiles `win32lib.c` with
+  `-D_CRT_DECLARE_NONSTDC_NAMES=0`. Without it, `win32lib.h`'s `#define stat
+  _stat` combined with the UCRT's `#define _stat _stat64i32` (`sys/stat.h`)
+  rewrote the NAME of the UCRT's POSIX `stat()` compatibility wrapper to
+  `_stat64i32`, so `win32lib.o` emitted its own `_stat64i32` definition — which
+  collides with the real (static-CRT) `_stat64i32` (`LNK2005`) in a downstream
+  `+crt-static` + fat-LTO release link. It surfaces ONLY in such a release link
+  (not a plain `cargo build`) and only where the SDK makes the wrapper external
+  (`_CRT_NONSTANDARD_STATIC`). Disabling the UCRT's POSIX-name compat wrappers —
+  which `win32lib.h` already re-provides via its own `_`-prefixed remapping —
+  drops the mangled definition entirely (`win32lib.o` now merely *references* the
+  real `_stat64i32`, 0 definitions). Fixes `dginev/latexml-oxide`'s Windows
+  release `.exe`. No API change; only affects the opt-in Windows-MSVC
+  `build_from_source` leg.
+
 ## [0.3.2] 2026-07-14 — subprocess backend: never block on MiKTeX's on-the-fly installer
 
 * **The subprocess backend no longer deadlocks on MiKTeX package installation.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "kpathsea"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kpathsea_sys",
  "which",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "kpathsea_sys"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "cc",
  "pkg-config",

--- a/kpathsea/Cargo.toml
+++ b/kpathsea/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kpathsea"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>", "Emily Eisenberg <xymostech@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -21,7 +21,7 @@ name = "kpathsea"
 build-from-source = ["kpathsea_sys/build_from_source"]
 
 [dependencies]
-kpathsea_sys = { version = "0.2.2", path = "../kpathsea_sys" }
+kpathsea_sys = { version = "0.2.3", path = "../kpathsea_sys" }
 which = "8"
 
 [build-dependencies]

--- a/kpathsea_sys/Cargo.toml
+++ b/kpathsea_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kpathsea_sys"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 edition = "2024"
 links = "kpathsea"

--- a/kpathsea_sys/build.rs
+++ b/kpathsea_sys/build.rs
@@ -153,6 +153,18 @@ fn try_build_from_source() -> bool {
         "NO_KPSE_DLL",
         "_CRT_SECURE_NO_WARNINGS",
         "_CRT_NONSTDC_NO_WARNINGS",
+        // Drop the UCRT's POSIX-name compat wrappers (`stat`, `fstat`, `open`,
+        // …). win32lib.h already `#define`s those POSIX names to the `_`-prefixed
+        // CRT entry points, so the wrappers are unused here — and worse,
+        // win32lib.h's `#define stat _stat` combined with the UCRT's `#define
+        // _stat _stat64i32` rewrites the wrapper's NAME to `_stat64i32`, so
+        // win32lib.o emits a strong `_stat64i32` that collides with the real
+        // (static-CRT) one under `+crt-static` + fat-LTO (LNK2005 — surfaces only
+        // in a downstream maxperf/LTO release link, not a plain `cargo build`).
+        // Setting this to 0 forces corecrt.h's `_CRT_INTERNAL_NONSTDC_NAMES` to
+        // 0, which gates those wrappers off. Fixes dginev/latexml-oxide's Windows
+        // release .exe.
+        "_CRT_DECLARE_NONSTDC_NAMES=0",
       ],
       // OS imports: shell32 (CommandLineToArgvW), user32 (CharLowerA),
       // advapi32 (GetUserNameA), pulled in by win32lib.c / knj.c / hash.c.
@@ -221,7 +233,12 @@ fn try_build_from_source() -> bool {
     .define("MAKE_KPSE_DLL", None)
     .warnings(false);
   for d in leg.defines {
-    build.define(d, None);
+    // Support `NAME=VALUE` entries (e.g. `_CRT_DECLARE_NONSTDC_NAMES=0`), not
+    // only valueless `-DNAME`.
+    match d.split_once('=') {
+      Some((name, value)) => build.define(name, value),
+      None => build.define(d, None),
+    };
   }
   for f in KPATHSEA_COMMON_SOURCES.iter().chain(leg.sources) {
     build.file(src.join(f));


### PR DESCRIPTION
The MSVC `build_from_source` leg fails to link into a `+crt-static` + fat-LTO binary:

```
libucrt.lib(stat.obj): error LNK2005: _stat64i32 already defined in kpathsea_sys...rlib(...win32lib.o)
```

**Cause.** `win32lib.h` does `#define stat _stat`; UCRT's `<sys/stat.h>` does `#define _stat _stat64i32` and emits a POSIX `stat()` compatibility inline wrapper. With both active, the wrapper's *name* is rewritten `stat`→`_stat`→`_stat64i32`, so `win32lib.o` emits its own `_stat64i32` definition, colliding with the real static-CRT one. It only manifests in a downstream release link (`+crt-static` + fat-LTO pulls `libucrt`'s `stat.obj`) and only where the SDK's `_CRT_NONSTANDARD_STATIC` makes the wrapper external — so a plain `cargo build` links fine, which is how it slipped past CI.

**Fix.** Compile the MSVC leg with `-D_CRT_DECLARE_NONSTDC_NAMES=0`, gating off the UCRT's POSIX-name compat wrappers (`win32lib.h` already re-provides them via its own `_`-prefixed remapping). Verified with `dumpbin`: `win32lib.o` now has **0** definitions of `_stat64i32` (only a reference to the real one), down from a strong def. Also lets the per-leg `defines` list take `NAME=VALUE` entries.

`kpathsea_sys` 0.2.2 → 0.2.3, `kpathsea` 0.3.2 → 0.3.3. Fixes dginev/latexml-oxide's Windows release `.exe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)